### PR TITLE
input now returns if passed object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 dist/angular-emoji-hd.zip
+/bower_components

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -171,6 +171,7 @@
     angular.module("dbaq.emoji", []).filter("emoji", function () {
         return function (input) {
             if (input === undefined) return;
+            if (typeof input === "object") return input;
             return input.replace(rEmojis, function (match, text) {
                 return "<i class='emoji emoji_" + text + "' title=':" + text + ":'></i>";
             });


### PR DESCRIPTION
Had an issue where I had multiple filters being applied while passing in an object. This filter conflicts with another due to returning a message in $sce.trustAsHtml then emoji filter being ran after.

![](http://i.imgur.com/t7p7cga.png)

@dbaq Reopening now with updates. Also added bower folder to ignore. Sorry about the confusion!
