### PR TITLE
Support for emoji aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/angular-emoji-hd.zip
 /bower_components
 lib/emoji.css
 .sass-cache
+.idea

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -165,17 +165,65 @@
             "large_blue_circle", "large_blue_diamond", "large_orange_diamond",
             "small_blue_diamond", "small_orange_diamond", "small_red_triangle",
             "small_red_triangle_down", "shipit"
-        ],
-        rEmojis = new RegExp(":(" + emojis.join("|") + "):", "g");
+        ];
+
+    var rEmojis = new RegExp(":(" + emojis.join("|") + "):", "g");
+
+    var aliases = {};
+    var rAliases;
 
     angular.module("dbaq.emoji", []).filter("emoji", function () {
         return function (input) {
             if (input === undefined) return;
             if (typeof input === "object") return input;
-            return input.replace(rEmojis, function (match, text) {
-                return "<i class='emoji emoji_" + text + "' title=':" + text + ":'></i>";
-            });
+
+            return input
+                .replace(rAliases, function (match, text) {
+                    return aliases[text];
+                })
+                .replace(rEmojis, function (match, text) {
+                    return "<i class='emoji emoji_" + text + "' title=':" + text + ":'></i>";
+                });
         };
     });
+
+    angular.module("dbaq.emoji").provider("emojiConfig", function () {
+        var LOG_PREFIX = "emoji | ";
+
+        var escapedAliases = [];
+        var specialRegexCharacters = ["(", ")", ".", ",", "$", "^", "+", "*", "[", "]", "{", "}", "|"];
+        var rSafeCharacters = new RegExp("(\\" + specialRegexCharacters.join("|\\") + ")", "g");
+
+        return {
+            addAlias: function (emoji, alias) {
+                if (emojis.indexOf(emoji) === -1) {
+                    throw new Error(LOG_PREFIX + "unknown emoji: " + emoji);
+                }
+
+                if (typeof alias !== "string") {
+                    throw new Error(LOG_PREFIX + "alias is not a string");
+                }
+
+                aliases[alias] = ":" + emoji + ":";
+
+                // escape special regex characters
+                alias = alias.replace(rSafeCharacters, function (match, text) {
+                    return "\\" + text;
+                });
+
+                escapedAliases.push(alias);
+            },
+            $get: function () {
+                return {
+                    escapedAliases: escapedAliases
+                };
+            }
+        };
+    });
+
+    angular.module("dbaq.emoji").run(function (emojiConfig) {
+        rAliases = new RegExp("(" + emojiConfig.escapedAliases.join("|") + ")", "g");
+    });
+
 
 }());


### PR DESCRIPTION
Support for emoji aliases issue #8.

Here is example on [plnrk.co](http://embed.plnkr.co/TVFkAhyUogvL7nxmZWSe/).

To add alias you need to inject `emojiConfigProvider` in `.config` phase.
This is how you use it: `emojiConfigProvider.addAlias("smile", ":)");`

This will turn `:)` into :smile: