### PR TITLE
Add grunt as devDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "description": "An AngularJS filter for replacing emoji codes with high-definition emoticons (Retina friendly).",
   "homepage": "https://github.com/dbaq/angular-emoji-filter-hd",
   "main": "./dist/emoji.min.js",
-  "dependencies": {
+  "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-copy": "^0.4.1",
     "grunt-contrib-clean": "^0.4.1",


### PR DESCRIPTION
I had a problem because of Grunt adding `grunt-legacy-utils` which in turn add `which` in a very old version. This conflicted with the system `which` as it doesn't support the same parameters.
So adding Grunt in `devDependencies` instead of `dependencies` will avoid it to be installed in my repository